### PR TITLE
README.rst: Fix link bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-OBS Studio <https://obsproject.com>
+`OBS Studio <https://obsproject.com>`_
 ===================================
 
 .. image:: https://dev.azure.com/obsjim/obsjim/_apis/build/status/obsproject.obs-studio?branchName=master


### PR DESCRIPTION
The first link to the obsproject.com page was first displayed like this: 
![obsbefore](https://user-images.githubusercontent.com/23634285/110676808-aa96ee00-81d4-11eb-911c-0cc545279900.png)

It has now changed to this:
![obsafter](https://user-images.githubusercontent.com/23634285/110676816-aec30b80-81d4-11eb-8b22-5e711fa95ac8.png)

I don't know if this was intentional, but in case it wasn't, here's a fix!